### PR TITLE
feat: house ad — Buy Me a Coffee card every 10th article

### DIFF
--- a/components/deck/AdCard.tsx
+++ b/components/deck/AdCard.tsx
@@ -2,9 +2,18 @@
 
 import { Coffee } from 'lucide-react';
 
+const BMAC_URL = 'https://buymeacoffee.com/kianfongl';
+
+type ElectronWindow = Window & { electronAPI?: { openExternal: (url: string) => void } };
+
 export function AdCard() {
   const handleClick = () => {
-    window.open('https://buymeacoffee.com/kianfongl', '_blank', 'noopener,noreferrer');
+    const electronAPI = (window as ElectronWindow).electronAPI;
+    if (electronAPI) {
+      electronAPI.openExternal(BMAC_URL);
+    } else {
+      window.open(BMAC_URL, '_blank', 'noopener,noreferrer');
+    }
   };
 
   return (
@@ -15,8 +24,9 @@ export function AdCard() {
           <p className="text-sm text-foreground">
             Like IntelliDeck?{' '}
             <button
+              type="button"
               onClick={handleClick}
-              className="text-accent hover:underline font-medium"
+              className="text-accent hover:underline font-medium focus:outline-none focus-visible:ring-2 focus-visible:ring-accent rounded"
             >
               Buy Fong a coffee.
             </button>

--- a/components/deck/AdCard.tsx
+++ b/components/deck/AdCard.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { Coffee } from 'lucide-react';
+
+export function AdCard() {
+  const handleClick = () => {
+    window.open('https://buymeacoffee.com/kianfongl', '_blank', 'noopener,noreferrer');
+  };
+
+  return (
+    <div className="border-b border-border px-3 py-3 bg-accent-light/40 hover:bg-accent-light/60 transition-colors">
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex items-center gap-2 min-w-0">
+          <Coffee className="w-4 h-4 text-accent flex-shrink-0" />
+          <p className="text-sm text-foreground">
+            Like IntelliDeck?{' '}
+            <button
+              onClick={handleClick}
+              className="text-accent hover:underline font-medium"
+            >
+              Buy Fong a coffee.
+            </button>
+          </p>
+        </div>
+        <span className="text-[10px] text-foreground-secondary flex-shrink-0 mt-0.5">Support</span>
+      </div>
+    </div>
+  );
+}

--- a/components/deck/Column.tsx
+++ b/components/deck/Column.tsx
@@ -5,12 +5,14 @@ import { RefreshCw, X, Loader2, AlertCircle, GripVertical, GripHorizontal } from
 import { CheckCheck } from 'lucide-react';
 import { useReadArticlesStore } from '@/lib/read-articles-store';
 import { ColumnSettingsMenu } from './ColumnSettingsMenu';
-import { Column as ColumnType, Article } from '@/lib/types';
+import { Column as ColumnType, Article, FeedItem } from '@/lib/types';
 import { useDeckStore, DEFAULT_COLUMN_WIDTH, MIN_COLUMN_WIDTH, MAX_COLUMN_WIDTH } from '@/lib/store';
 import { useArticlesStore } from '@/lib/articles-store';
 import { useSettingsStore, ArticleAgeFilter } from '@/lib/settings-store';
 import { deleteColumnRequest, updateColumnRequest } from '@/lib/deck-client';
 import { ArticleCard } from './ArticleCard';
+import { AdCard } from './AdCard';
+import { injectAds } from '@/lib/injectAds';
 import { cn } from '@/lib/utils';
 import { DraggableAttributes, DraggableSyntheticListeners } from '@dnd-kit/core';
 
@@ -377,15 +379,22 @@ export function Column({ column, onArticleClick, selectedArticleId, refreshTrigg
                 </div>
               );
             }
-            return filteredArticles.map((article) => (
-              <ArticleCard
-                key={article.id}
-                article={article}
-                viewMode={column.settings.viewMode}
-                onClick={onArticleClick}
-                isSelected={article.id === selectedArticleId}
-              />
-            ));
+            const feedItems: FeedItem[] = injectAds(filteredArticles);
+            return feedItems.map((item) => {
+              if ('type' in item && item.type === 'ad') {
+                return <AdCard key={item.id} />;
+              }
+              const article = item as Article;
+              return (
+                <ArticleCard
+                  key={article.id}
+                  article={article}
+                  viewMode={column.settings.viewMode}
+                  onClick={onArticleClick}
+                  isSelected={article.id === selectedArticleId}
+                />
+              );
+            });
           })()
         )}
       </div>

--- a/docs/superpowers/plans/2026-05-01-house-ad-feed-injection.md
+++ b/docs/superpowers/plans/2026-05-01-house-ad-feed-injection.md
@@ -1,0 +1,320 @@
+# House Ad Feed Injection Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Insert a "Buy Me a Coffee" house ad card after every 10th article in each feed column, keeping the free macOS app monetisable without any external ad network.
+
+**Architecture:** Add `AdSentinel` and `FeedItem` types to `lib/types.ts`, create a new `AdCard` component styled to match `ArticleCard`, and add an `injectAds` helper in `Column.tsx` that splices sentinels into the articles array before rendering.
+
+**Tech Stack:** Next.js 14, React, TypeScript, Tailwind CSS, Lucide icons, Electron (external links via `window.open`)
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `lib/types.ts` | Modify | Add `AdSentinel` and `FeedItem` union type |
+| `components/deck/AdCard.tsx` | Create | Buy Me a Coffee card, styled to match `ArticleCard` |
+| `components/deck/Column.tsx` | Modify | Add `injectAds` helper, update render loop to handle `FeedItem[]` |
+| `lib/injectAds.test.ts` | Create | Unit tests for the `injectAds` pure function |
+| `lib/injectAds.ts` | Create | Extracted pure `injectAds` helper (testable without React) |
+
+---
+
+## Task 1: Add types to `lib/types.ts`
+
+**Files:**
+- Modify: `lib/types.ts`
+
+- [ ] **Step 1: Add `AdSentinel` and `FeedItem` to the end of `lib/types.ts`**
+
+Append after the last export in the file:
+
+```ts
+export type AdSentinel = { type: 'ad'; id: string };
+export type FeedItem = Article | AdSentinel;
+```
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+```bash
+cd /Users/fong/SynologyDrive/Jarvis/Projects/IntelliDeck/.claude/worktrees/amazing-buck-4de8ed
+npx tsc --noEmit
+```
+
+Expected: no errors related to types.ts
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add lib/types.ts
+git commit -m "feat: add AdSentinel and FeedItem types"
+```
+
+---
+
+## Task 2: Extract and test the `injectAds` pure function
+
+**Files:**
+- Create: `lib/injectAds.ts`
+- Create: `lib/injectAds.test.ts`
+
+- [ ] **Step 1: Write the failing tests in `lib/injectAds.test.ts`**
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { injectAds } from './injectAds';
+import { Article } from './types';
+
+function makeArticles(count: number): Article[] {
+  return Array.from({ length: count }, (_, i) => ({
+    id: `a${i}`,
+    title: `Article ${i}`,
+    link: `https://example.com/${i}`,
+    pubDate: new Date().toISOString(),
+  }));
+}
+
+describe('injectAds', () => {
+  it('returns articles unchanged when count is less than 10', () => {
+    const articles = makeArticles(9);
+    const result = injectAds(articles);
+    expect(result).toHaveLength(9);
+    expect(result.every((item) => !('type' in item && item.type === 'ad'))).toBe(true);
+  });
+
+  it('inserts one ad after the 10th article', () => {
+    const articles = makeArticles(10);
+    const result = injectAds(articles);
+    expect(result).toHaveLength(11);
+    expect(result[10]).toEqual({ type: 'ad', id: 'ad-9' });
+  });
+
+  it('inserts two ads for 20 articles', () => {
+    const articles = makeArticles(20);
+    const result = injectAds(articles);
+    expect(result).toHaveLength(22);
+    expect(result[10]).toEqual({ type: 'ad', id: 'ad-9' });
+    expect(result[21]).toEqual({ type: 'ad', id: 'ad-19' });
+  });
+
+  it('preserves article order', () => {
+    const articles = makeArticles(12);
+    const result = injectAds(articles);
+    const articleItems = result.filter((item) => !('type' in item && item.type === 'ad'));
+    expect(articleItems.map((a) => (a as Article).id)).toEqual(articles.map((a) => a.id));
+  });
+
+  it('returns empty array for empty input', () => {
+    expect(injectAds([])).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+npx vitest run lib/injectAds.test.ts
+```
+
+Expected: FAIL — `Cannot find module './injectAds'`
+
+- [ ] **Step 3: Implement `lib/injectAds.ts`**
+
+```ts
+import { Article, AdSentinel, FeedItem } from './types';
+
+export function injectAds(articles: Article[]): FeedItem[] {
+  const result: FeedItem[] = [];
+  articles.forEach((article, i) => {
+    result.push(article);
+    if ((i + 1) % 10 === 0) {
+      result.push({ type: 'ad', id: `ad-${i}` } satisfies AdSentinel);
+    }
+  });
+  return result;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+npx vitest run lib/injectAds.test.ts
+```
+
+Expected: all 5 tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/injectAds.ts lib/injectAds.test.ts
+git commit -m "feat: add injectAds helper with tests"
+```
+
+---
+
+## Task 3: Create `AdCard` component
+
+**Files:**
+- Create: `components/deck/AdCard.tsx`
+
+- [ ] **Step 1: Create `components/deck/AdCard.tsx`**
+
+```tsx
+'use client';
+
+import { Coffee } from 'lucide-react';
+
+export function AdCard() {
+  const handleClick = () => {
+    window.open('https://buymeacoffee.com/kianfongl', '_blank', 'noopener,noreferrer');
+  };
+
+  return (
+    <div className="border-b border-border px-3 py-3 bg-accent-light/40 hover:bg-accent-light/60 transition-colors">
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex items-center gap-2 min-w-0">
+          <Coffee className="w-4 h-4 text-accent flex-shrink-0" />
+          <p className="text-sm text-foreground">
+            Like IntelliDeck?{' '}
+            <button
+              onClick={handleClick}
+              className="text-accent hover:underline font-medium"
+            >
+              Buy Fong a coffee.
+            </button>
+          </p>
+        </div>
+        <span className="text-[10px] text-foreground-secondary flex-shrink-0 mt-0.5">Support</span>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+```bash
+npx tsc --noEmit
+```
+
+Expected: no errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add components/deck/AdCard.tsx
+git commit -m "feat: add AdCard house ad component"
+```
+
+---
+
+## Task 4: Wire `injectAds` into `Column.tsx`
+
+**Files:**
+- Modify: `components/deck/Column.tsx`
+
+- [ ] **Step 1: Add imports at the top of `Column.tsx`**
+
+After the existing imports, add:
+
+```ts
+import { AdCard } from './AdCard';
+import { injectAds } from '@/lib/injectAds';
+import { FeedItem } from '@/lib/types';
+```
+
+The existing import line `import { Column as ColumnType, Article } from '@/lib/types';` stays — just append `FeedItem` to it:
+
+```ts
+import { Column as ColumnType, Article, FeedItem } from '@/lib/types';
+```
+
+And add the AdCard/injectAds imports separately:
+
+```ts
+import { AdCard } from './AdCard';
+import { injectAds } from '@/lib/injectAds';
+```
+
+- [ ] **Step 2: Replace the articles render loop inside `Column.tsx`**
+
+Find this block (lines 380–388):
+
+```tsx
+return filteredArticles.map((article) => (
+  <ArticleCard
+    key={article.id}
+    article={article}
+    viewMode={column.settings.viewMode}
+    onClick={onArticleClick}
+    isSelected={article.id === selectedArticleId}
+  />
+));
+```
+
+Replace with:
+
+```tsx
+const feedItems: FeedItem[] = injectAds(filteredArticles);
+return feedItems.map((item) => {
+  if ('type' in item && item.type === 'ad') {
+    return <AdCard key={item.id} />;
+  }
+  return (
+    <ArticleCard
+      key={item.id}
+      article={item}
+      viewMode={column.settings.viewMode}
+      onClick={onArticleClick}
+      isSelected={item.id === selectedArticleId}
+    />
+  );
+});
+```
+
+- [ ] **Step 3: Verify TypeScript compiles**
+
+```bash
+npx tsc --noEmit
+```
+
+Expected: no errors
+
+- [ ] **Step 4: Run existing tests to confirm nothing broke**
+
+```bash
+npx vitest run
+```
+
+Expected: all tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add components/deck/Column.tsx
+git commit -m "feat: inject house ad card every 10th article in feed columns"
+```
+
+---
+
+## Task 5: Manual verification
+
+- [ ] **Step 1: Start the dev server**
+
+```bash
+npm run dev
+```
+
+- [ ] **Step 2: Open the app and verify**
+
+- Open a column with 10+ articles
+- Scroll down — after the 10th article card, an ad card should appear with a coffee icon and "Like IntelliDeck? Buy Fong a coffee."
+- A "Support" label should be visible in the top-right of the card
+- Clicking "Buy Fong a coffee." should open `https://buymeacoffee.com/kianfongl` in the default browser
+- Columns with fewer than 10 articles should show no ad card
+
+- [ ] **Step 3: Check dark/light theme**
+
+Toggle the theme and confirm the `AdCard` background (`bg-accent-light/40`) looks good in both modes.

--- a/docs/superpowers/specs/2026-05-01-house-ad-feed-injection-design.md
+++ b/docs/superpowers/specs/2026-05-01-house-ad-feed-injection-design.md
@@ -1,0 +1,77 @@
+# House Ad Feed Injection — Design Spec
+
+**Date:** 2026-05-01  
+**Status:** Approved
+
+## Summary
+
+Insert a "Buy Me a Coffee" house ad card into each feed column every 10th article. The app remains free to download; this gives users a low-friction way to support development while keeping the experience native and non-intrusive.
+
+## Goals
+
+- Monetise the free macOS Electron app via voluntary support
+- Ad card feels native alongside `ArticleCard` (not a banner, not a popup)
+- Zero external ad network dependency — fully self-contained
+
+## Non-Goals
+
+- External ad networks (AdSense, Carbon, EthicalAds)
+- Configurable ad frequency per user
+- Analytics/impression tracking
+
+## Architecture
+
+**Approach:** Inject a typed ad sentinel into the articles array before rendering. The `Column` component maps over a `FeedItem[]` union type and renders either `ArticleCard` or `AdCard` based on the item type.
+
+## Data Types
+
+Add to `lib/types.ts`:
+
+```ts
+export type AdSentinel = { type: 'ad'; id: string };
+export type FeedItem = Article | AdSentinel;
+```
+
+## New Component: `components/deck/AdCard.tsx`
+
+- Matches `ArticleCard` card styling: same border, padding, border-radius, dark/light theme support
+- Lucide `Coffee` icon
+- Text: "Like IntelliDeck? Buy Fong a coffee."
+- Small "Support" label (top-right corner) to be transparent about what it is
+- CTA button/link that opens `https://buymeacoffee.com/kianfongl` via `window.open` with `_blank` target (Electron-safe external link)
+
+## Column.tsx Changes
+
+Add a pure helper function:
+
+```ts
+function injectAds(articles: Article[]): FeedItem[] {
+  const result: FeedItem[] = [];
+  articles.forEach((article, i) => {
+    result.push(article);
+    if ((i + 1) % 10 === 0) {
+      result.push({ type: 'ad', id: `ad-${i}` });
+    }
+  });
+  return result;
+}
+```
+
+Call `injectAds` on the final filtered/deduplicated articles array before mapping to JSX. The `.map()` branches on `item.type === 'ad'` to render `AdCard`, otherwise `ArticleCard`.
+
+## Behaviour & Edge Cases
+
+| Scenario | Behaviour |
+|----------|-----------|
+| Column has < 10 articles | No ad shown |
+| Column has exactly 10 articles | One ad after the 10th |
+| Articles refresh | Ads re-inject based on new array; no flicker (index-based, not random) |
+| User clicks ad | External link opens in default browser; feed unaffected |
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `lib/types.ts` | Add `AdSentinel` and `FeedItem` types |
+| `components/deck/AdCard.tsx` | New component |
+| `components/deck/Column.tsx` | Add `injectAds` helper, update render loop |

--- a/lib/injectAds.test.ts
+++ b/lib/injectAds.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { injectAds } from './injectAds';
+import { Article } from './types';
+
+function makeArticles(count: number): Article[] {
+  return Array.from({ length: count }, (_, i) => ({
+    id: `a${i}`,
+    title: `Article ${i}`,
+    link: `https://example.com/${i}`,
+    pubDate: new Date().toISOString(),
+  }));
+}
+
+describe('injectAds', () => {
+  it('returns articles unchanged when count is less than 10', () => {
+    const articles = makeArticles(9);
+    const result = injectAds(articles);
+    expect(result).toHaveLength(9);
+    expect(result.every((item) => !('type' in item && item.type === 'ad'))).toBe(true);
+  });
+
+  it('inserts one ad after the 10th article', () => {
+    const articles = makeArticles(10);
+    const result = injectAds(articles);
+    expect(result).toHaveLength(11);
+    expect(result[10]).toEqual({ type: 'ad', id: 'ad-9' });
+  });
+
+  it('inserts two ads for 20 articles', () => {
+    const articles = makeArticles(20);
+    const result = injectAds(articles);
+    expect(result).toHaveLength(22);
+    expect(result[10]).toEqual({ type: 'ad', id: 'ad-9' });
+    expect(result[21]).toEqual({ type: 'ad', id: 'ad-19' });
+  });
+
+  it('preserves article order', () => {
+    const articles = makeArticles(12);
+    const result = injectAds(articles);
+    const articleItems = result.filter((item) => !('type' in item && item.type === 'ad'));
+    expect(articleItems.map((a) => (a as Article).id)).toEqual(articles.map((a) => a.id));
+  });
+
+  it('returns empty array for empty input', () => {
+    expect(injectAds([])).toEqual([]);
+  });
+});

--- a/lib/injectAds.ts
+++ b/lib/injectAds.ts
@@ -1,0 +1,12 @@
+import { Article, AdSentinel, FeedItem } from './types';
+
+export function injectAds(articles: Article[]): FeedItem[] {
+  const result: FeedItem[] = [];
+  articles.forEach((article, i) => {
+    result.push(article);
+    if ((i + 1) % 10 === 0) {
+      result.push({ type: 'ad', id: `ad-${i}` } satisfies AdSentinel);
+    }
+  });
+  return result;
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -78,3 +78,6 @@ export interface SearchRule {
   keywords: string[];
   lastRunAt: string | null;
 }
+
+export type AdSentinel = { type: 'ad'; id: string };
+export type FeedItem = Article | AdSentinel;


### PR DESCRIPTION
## Summary

- Adds a "Buy Me a Coffee" house ad card that appears after every 10th article in each feed column
- Uses `electronAPI.openExternal` for safe link opening in the Electron app (falls back to `window.open` for web)
- Fully self-contained — no external ad network, no tracking, no dependencies

## Changes

- `lib/types.ts` — new `AdSentinel` and `FeedItem` union types
- `lib/injectAds.ts` — pure helper that splices ad sentinels every 10th article
- `lib/injectAds.test.ts` — 5 unit tests covering edge cases
- `components/deck/AdCard.tsx` — themed card with Coffee icon, "Like IntelliDeck? Buy Fong a coffee." copy, and "Support" label
- `components/deck/Column.tsx` — wired to render `AdCard` for ad items in the feed loop

## Test Plan

- [ ] Run `npm test` — all 16 tests should pass
- [ ] Start the app and open a column with 10+ articles — ad card appears after the 10th
- [ ] Columns with fewer than 10 articles show no ad
- [ ] Clicking "Buy Fong a coffee." opens `https://buymeacoffee.com/kianfongl` in the system browser
- [ ] Ad card looks correct in both dark and light themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)