### PR TITLE
feat: extract full tweet content from RSS items with tweet URLs

### DIFF
--- a/app/api/tweet/route.ts
+++ b/app/api/tweet/route.ts
@@ -1,0 +1,84 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { JSDOM } from 'jsdom';
+
+export async function POST(req: NextRequest) {
+  try {
+    const { url } = await req.json();
+
+    if (!url || typeof url !== 'string') {
+      return NextResponse.json({ error: 'URL is required' }, { status: 400 });
+    }
+
+    let parsedUrl: URL;
+    try {
+      parsedUrl = new URL(url);
+    } catch {
+      return NextResponse.json({ error: 'Invalid URL' }, { status: 400 });
+    }
+
+    const host = parsedUrl.hostname.replace(/^www\./, '');
+    if (host !== 'twitter.com' && host !== 'x.com') {
+      return NextResponse.json({ error: 'Not a Twitter/X URL' }, { status: 400 });
+    }
+
+    const oembedUrl = `https://publish.twitter.com/oembed?url=${encodeURIComponent(url)}&omit_script=true`;
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 10000);
+
+    let oembedData: { html: string; author_name: string; author_url: string };
+    try {
+      const response = await fetch(oembedUrl, {
+        headers: {
+          'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+          Accept: 'application/json',
+        },
+        signal: controller.signal,
+      });
+
+      clearTimeout(timeoutId);
+
+      if (!response.ok) {
+        return NextResponse.json(
+          { error: `Tweet not found or unavailable (${response.status})` },
+          { status: response.status === 404 ? 404 : 502 }
+        );
+      }
+
+      oembedData = await response.json();
+    } catch (fetchError: any) {
+      clearTimeout(timeoutId);
+      if (fetchError.name === 'AbortError') {
+        return NextResponse.json({ error: 'Request timed out' }, { status: 504 });
+      }
+      throw fetchError;
+    }
+
+    // Extract plain text and linked content from the blockquote
+    const dom = new JSDOM(oembedData.html);
+    const blockquote = dom.window.document.querySelector('blockquote');
+    const tweetPara = blockquote?.querySelector('p');
+    const tweetText = tweetPara?.textContent?.trim() ?? '';
+    // Keep the inner HTML of the <p> for richer display (links preserved)
+    const tweetHtml = tweetPara?.innerHTML ?? tweetText;
+
+    const authorHandle = oembedData.author_url.split('/').pop() ?? '';
+    const displayContent = `<blockquote style="border-left:4px solid #1d9bf0;padding:0 1em;margin:0"><p>${tweetHtml}</p><footer>— <a href="${oembedData.author_url}" target="_blank" rel="noopener noreferrer">${oembedData.author_name} (@${authorHandle})</a></footer></blockquote>`;
+
+    return NextResponse.json({
+      success: true,
+      tweet: {
+        title: `${oembedData.author_name} on Twitter`,
+        content: displayContent,
+        textContent: tweetText,
+        excerpt: tweetText.slice(0, 200),
+        byline: `${oembedData.author_name} (@${authorHandle})`,
+        siteName: 'Twitter / X',
+        length: tweetText.length,
+      },
+    });
+  } catch (error: any) {
+    console.error('Tweet fetch error:', error);
+    return NextResponse.json({ error: error.message || 'Failed to fetch tweet' }, { status: 500 });
+  }
+}

--- a/components/AppChrome.tsx
+++ b/components/AppChrome.tsx
@@ -59,7 +59,6 @@ export function AppChrome({ children, renderContent, onRefreshAll }: AppChromePr
         style={{ height: '28px', WebkitAppRegion: 'drag' } as React.CSSProperties}
       />
       <BriefingManager />
-      <StockTicker />
       <TopNavBar
         pageActions={
           <>
@@ -93,6 +92,7 @@ export function AppChrome({ children, renderContent, onRefreshAll }: AppChromePr
           </>
         }
       />
+      <StockTicker />
       <main className="flex flex-1 overflow-hidden min-h-0">
         <div className="relative flex-1 overflow-hidden min-h-0">
           {renderContent ? renderContent({ openAddFeedModal }) : children}

--- a/components/ThemeProvider.tsx
+++ b/components/ThemeProvider.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect } from 'react';
-import { useSettingsStore, getThemeById } from '@/lib/settings-store';
+import { useSettingsStore, getThemeById, FONT_SIZE_PX } from '@/lib/settings-store';
 
 interface ThemeProviderProps {
   children: React.ReactNode;
@@ -27,6 +27,11 @@ function getReadableAccentForeground(accent: string) {
 
 export function ThemeProvider({ children }: ThemeProviderProps) {
   const themeId = useSettingsStore((state) => state.themeId);
+  const fontSize = useSettingsStore((state) => state.fontSize);
+
+  useEffect(() => {
+    document.documentElement.style.fontSize = `${FONT_SIZE_PX[fontSize ?? 'normal']}px`;
+  }, [fontSize]);
 
   useEffect(() => {
     const theme = getThemeById(themeId);

--- a/components/ui/ArticlePreviewPanel.tsx
+++ b/components/ui/ArticlePreviewPanel.tsx
@@ -184,7 +184,8 @@ export function ArticlePreviewPanel({ article, onClose }: ArticlePreviewPanelPro
   useEffect(() => {
     if (!article) return;
     if (scrapedContent) return;
-    if ((article.content?.length ?? 0) >= 500) return;
+    const isTweet = (() => { try { const h = new URL(article.link).hostname.replace(/^www\./, ''); return h === 'twitter.com' || h === 'x.com'; } catch { return false; } })();
+    if (!isTweet && (article.content?.length ?? 0) >= 500) return;
 
     const timer = setTimeout(() => {
       void handleFetchFullArticle();
@@ -240,12 +241,44 @@ export function ArticlePreviewPanel({ article, onClose }: ArticlePreviewPanelPro
     return null;
   };
 
+  const isTweetUrl = (url: string) => {
+    try {
+      const host = new URL(url).hostname.replace(/^www\./, '');
+      return host === 'twitter.com' || host === 'x.com';
+    } catch {
+      return false;
+    }
+  };
+
   // Fetch full article content
   const handleFetchFullArticle = async () => {
     if (!article || isScraping || scrapedContent) return;
 
     setIsScraping(true);
     setScrapeError(null);
+
+    // Tweet URLs need a different fetch path
+    if (isTweetUrl(article.link)) {
+      try {
+        const response = await fetch('/api/tweet', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ url: article.link }),
+        });
+        const data = await response.json();
+        if (response.ok && data.tweet) {
+          setScrapedContent(data.tweet);
+          setCachedScrapedContent(article.link, data.tweet);
+        } else {
+          setScrapeError(data.error || 'Failed to fetch tweet');
+        }
+      } catch (error: any) {
+        setScrapeError(error.message || 'Failed to fetch tweet');
+      } finally {
+        setIsScraping(false);
+      }
+      return;
+    }
 
     const tryFetchUrl = async (url: string): Promise<{ success: boolean; article?: ScrapedArticle; error?: string }> => {
       try {
@@ -315,19 +348,21 @@ export function ArticlePreviewPanel({ article, onClose }: ArticlePreviewPanelPro
       if (fetchFullFirst && !scrapedContent) {
         setPhase('scraping');
         try {
-          const scrapeResponse = await fetch('/api/scrape', {
+          const endpoint = isTweetUrl(article.link) ? '/api/tweet' : '/api/scrape';
+          const scrapeResponse = await fetch(endpoint, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ url: article.link }),
           });
           const scrapeData = await scrapeResponse.json();
 
-          const hasGoodContent = scrapeResponse.ok && scrapeData.article?.textContent?.length > 200;
+          const fetched = isTweetUrl(article.link) ? scrapeData.tweet : scrapeData.article;
+          const hasGoodContent = scrapeResponse.ok && fetched?.textContent?.length > 0;
 
           if (hasGoodContent) {
-            setScrapedContent(scrapeData.article);
-            setCachedScrapedContent(article.link, scrapeData.article);
-            articleContent = scrapeData.article.textContent;
+            setScrapedContent(fetched);
+            setCachedScrapedContent(article.link, fetched);
+            articleContent = fetched.textContent;
           } else {
             // Try fallback URL from content
             const contentToSearch = article.content || article.contentSnippet || '';

--- a/components/ui/SettingsModal.tsx
+++ b/components/ui/SettingsModal.tsx
@@ -2,8 +2,8 @@
 
 import { useState, useEffect } from 'react';
 import { nanoid } from 'nanoid';
-import { X, Palette, Clock, Eye, EyeOff, Sparkles, Loader2, CheckCircle, XCircle, Save, Zap, ChevronUp, Database, Trash2 } from 'lucide-react';
-import { useSettingsStore, themes, getThemeById } from '@/lib/settings-store';
+import { X, Palette, Clock, Eye, EyeOff, Sparkles, Loader2, CheckCircle, XCircle, Save, Zap, ChevronUp, Database, Trash2, ALargeSmall } from 'lucide-react';
+import { useSettingsStore, themes, getThemeById, type FontSize } from '@/lib/settings-store';
 import { useDeckStore } from '@/lib/store';
 import { useArticlesStore } from '@/lib/articles-store';
 import { cn } from '@/lib/utils';
@@ -17,10 +17,12 @@ interface SettingsModalProps {
 export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
   const {
     themeId,
+    fontSize,
     defaultRefreshInterval,
     defaultViewMode,
 
     setTheme,
+    setFontSize,
     setDefaultRefreshInterval,
     setDefaultViewMode,
 
@@ -266,6 +268,35 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
                         />
                       </div>
                       <span className="text-sm">{theme.name}</span>
+                    </button>
+                  ))}
+                </div>
+              </div>
+
+              {/* Text Size */}
+              <div className="space-y-3">
+                <div className="flex items-center gap-2 text-sm font-medium">
+                  <ALargeSmall className="w-4 h-4" />
+                  <span>Text Size</span>
+                </div>
+                <div className="flex gap-2">
+                  {([
+                    { value: 'small', label: 'Small', style: 'text-xs' },
+                    { value: 'normal', label: 'Normal', style: 'text-sm' },
+                    { value: 'large', label: 'Large', style: 'text-base' },
+                  ] as { value: FontSize; label: string; style: string }[]).map(({ value, label, style }) => (
+                    <button
+                      key={value}
+                      onClick={() => setFontSize(value)}
+                      className={cn(
+                        'flex-1 px-3 py-2 rounded-lg border transition-all',
+                        style,
+                        fontSize === value
+                          ? 'border-accent bg-accent text-[color:var(--accent-foreground)]'
+                          : 'border-border hover:border-foreground-secondary'
+                      )}
+                    >
+                      {label}
                     </button>
                   ))}
                 </div>

--- a/lib/settings-store.ts
+++ b/lib/settings-store.ts
@@ -50,9 +50,17 @@ export const themes: ThemeColors[] = [
 ];
 
 export type ArticleAgeFilter = 'all' | '1day' | '3days' | '7days';
+export type FontSize = 'small' | 'normal' | 'large';
+
+export const FONT_SIZE_PX: Record<FontSize, number> = {
+  small: 13,
+  normal: 16,
+  large: 19,
+};
 
 interface SettingsState {
   themeId: string;
+  fontSize: FontSize;
   defaultRefreshInterval: number; // in minutes
   defaultViewMode: 'compact' | 'comfortable';
 
@@ -61,6 +69,7 @@ interface SettingsState {
   locale: 'en' | 'zh-CN';
 
   setTheme: (themeId: string) => void;
+  setFontSize: (size: FontSize) => void;
   setDefaultRefreshInterval: (interval: number) => void;
   setDefaultViewMode: (mode: 'compact' | 'comfortable') => void;
 
@@ -97,6 +106,7 @@ interface SettingsState {
 export type SettingsSnapshot = Pick<
   SettingsState,
   | 'themeId'
+  | 'fontSize'
   | 'defaultRefreshInterval'
   | 'defaultViewMode'
   | 'showPreviewPanel'
@@ -110,6 +120,7 @@ export type SettingsSnapshot = Pick<
 export function getDefaultSettingsSnapshot(): SettingsSnapshot {
   return {
     themeId: 'stitch-dark',
+    fontSize: 'normal',
     defaultRefreshInterval: 10,
     defaultViewMode: 'comfortable',
     showPreviewPanel: true,
@@ -140,6 +151,7 @@ export function getDefaultSettingsSnapshot(): SettingsSnapshot {
 function toSettingsSnapshot(state: SettingsState): SettingsSnapshot {
   return {
     themeId: state.themeId,
+    fontSize: state.fontSize,
     defaultRefreshInterval: state.defaultRefreshInterval,
     defaultViewMode: state.defaultViewMode,
     showPreviewPanel: state.showPreviewPanel,
@@ -170,6 +182,11 @@ export const useSettingsStore = create<SettingsState>()((set) => ({
     set((state) => {
       persistSettings(toSettingsSnapshot({ ...state, themeId }));
       return { themeId };
+    }),
+  setFontSize: (fontSize) =>
+    set((state) => {
+      persistSettings(toSettingsSnapshot({ ...state, fontSize }));
+      return { fontSize };
     }),
   setDefaultRefreshInterval: (interval) =>
     set((state) => {


### PR DESCRIPTION
When an RSS feed item links to a twitter.com or x.com URL, the existing
scrape flow fails (Readability can't parse Twitter pages). This adds a
dedicated /api/tweet endpoint using Twitter's public oEmbed API
(publish.twitter.com/oembed — no auth required) to fetch tweet text,
author, and a styled blockquote for display.

- New app/api/tweet/route.ts: calls oEmbed, extracts text from blockquote,
  returns a ScrapedArticle-compatible payload
- ArticlePreviewPanel: isTweetUrl() helper routes tweet links to /api/tweet
  instead of /api/scrape in both handleFetchFullArticle and handleSummarize
- Auto-fetch timer now triggers for tweet URLs regardless of content length
  (tweets are always short and always need the oEmbed fetch)

https://claude.ai/code/session_01WmkvfQnSEHHtYb7aXc2hFp