### PR TITLE
Remove Vercel demo site and related code

### DIFF
--- a/app/landing/page.tsx
+++ b/app/landing/page.tsx
@@ -309,7 +309,6 @@ export default function LandingPage() {
               <div className="flex gap-8 text-xs text-slate-500 font-medium">
                 <a href="https://github.com/mephistophelesbits/intellideck" className="hover:text-blue-500 transition-colors">GitHub Repo</a>
                 <a href="https://hub.docker.com/r/kianfong/intellideck" className="hover:text-blue-500 transition-colors">Docker Hub</a>
-                <a href="https://intellideck.vercel.app" className="hover:text-blue-500 transition-colors">Live Demo</a>
               </div>
               <div className="text-xs text-slate-400">
                 © 2026 IntelliDeck. Open Source & Privacy Focused.

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,10 +1,7 @@
 'use client';
 
-import LandingPage from '@/components/LandingPage';
 import { Dashboard } from '@/components/Dashboard';
 
 export default function Home() {
-  const isLandingMode = process.env.NEXT_PUBLIC_APP_MODE === 'landing';
-
-  return isLandingMode ? <LandingPage /> : <Dashboard />;
+  return <Dashboard />;
 }

--- a/components/LandingPage.tsx
+++ b/components/LandingPage.tsx
@@ -499,7 +499,7 @@ export default function LandingPage() {
                   <div className="titlebar-dots">
                     <span></span><span></span><span></span>
                   </div>
-                  <div className="titlebar-url">intellideck.vercel.app</div>
+                  <div className="titlebar-url">localhost:3000</div>
                   <span className="material-symbols-outlined text-green">lock</span>
                 </div>
                 <div className="screenshot-carousel" id="carousel">


### PR DESCRIPTION
- Remove Live Demo link (intellideck.vercel.app) from landing page footer
- Remove NEXT_PUBLIC_APP_MODE landing mode switch from app/page.tsx
- Replace vercel.app URL in browser mockup with localhost:3000

https://claude.ai/code/session_01AbxBGNLA2QhKEJfWsm4pWf